### PR TITLE
Upgrade to DynamiaTools v5.4.1

### DIFF
--- a/sources/api/pom.xml
+++ b/sources/api/pom.xml
@@ -26,13 +26,13 @@
     <parent>
         <groupId>tools.dynamia.modules</groupId>
         <artifactId>tools.dynamia.modules.saas.parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
     </parent>
     <artifactId>tools.dynamia.modules.saas.api</artifactId>
 
     <name>DynamiaModules - SaaS API</name>
     <url>https://www.dynamia.tools/modules/saas</url>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
 
     <build>
         <plugins>

--- a/sources/core/pom.xml
+++ b/sources/core/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>tools.dynamia.modules</groupId>
         <artifactId>tools.dynamia.modules.saas.parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
     </parent>
     <artifactId>tools.dynamia.modules.saas</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <name>DynamiaModules - SaaS Core</name>
     <url>https://www.dynamia.tools/modules/saas</url>
 
@@ -49,12 +49,12 @@
         <dependency>
             <groupId>tools.dynamia.modules</groupId>
             <artifactId>tools.dynamia.modules.saas.api</artifactId>
-            <version>3.4.1</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia.modules</groupId>
             <artifactId>tools.dynamia.modules.saas.jpa</artifactId>
-            <version>3.4.1</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/sources/core/src/main/java/tools/dynamia/modules/saas/AccountLocaleProvider.java
+++ b/sources/core/src/main/java/tools/dynamia/modules/saas/AccountLocaleProvider.java
@@ -24,16 +24,40 @@ import tools.dynamia.integration.sterotypes.Provider;
 
 import java.util.Locale;
 
+/**
+ * AccountLocaleProvider is an implementation of {@link LocaleProvider} for SaaS environments.
+ * <p>
+ * Provides the default {@link Locale} based on the current account session context.
+ * The priority for this provider is set to 10, making it suitable for account-level locale resolution.
+ * <p>
+ * If the account session or locale cannot be resolved, this provider returns null.
+ *
+ * @author Mario
+ */
 @Provider
 public class AccountLocaleProvider implements LocaleProvider {
-
+    /**
+     * Logger for this provider, using SLF4J.
+     */
     private final LoggingService logger = new SLF4JLoggingService(AccountLocaleProvider.class);
 
+    /**
+     * Returns the priority of this provider. Lower values indicate higher priority.
+     *
+     * @return the priority value (10)
+     */
     @Override
     public int getPriority() {
         return 10;
     }
 
+    /**
+     * Returns the default {@link Locale} for the current account session.
+     * <p>
+     * Attempts to retrieve the account locale from the current session. If unavailable, returns null.
+     *
+     * @return the account's default Locale, or null if not available
+     */
     @Override
     public Locale getDefaultLocale() {
         try {

--- a/sources/core/src/main/java/tools/dynamia/modules/saas/AccountTimeZoneProvider.java
+++ b/sources/core/src/main/java/tools/dynamia/modules/saas/AccountTimeZoneProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2023 Dynamia Soluciones IT S.A.S - NIT 900302344-1
+ * Colombia / South America
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tools.dynamia.modules.saas;
+
+import tools.dynamia.commons.TimeZoneProvider;
+import tools.dynamia.commons.logger.LoggingService;
+import tools.dynamia.commons.logger.SLF4JLoggingService;
+import tools.dynamia.integration.sterotypes.Provider;
+
+import java.time.ZoneId;
+
+/**
+ * AccountTimeZoneProvider is an implementation of {@link TimeZoneProvider} for SaaS environments.
+ * <p>
+ * Provides the default {@link ZoneId} based on the current account session context.
+ * The priority for this provider is set to 10, making it suitable for account-level time zone resolution.
+ * <p>
+ * If the account session or time zone cannot be resolved, this provider returns null.
+ *
+ * @author Mario
+ */
+@Provider
+public class AccountTimeZoneProvider implements TimeZoneProvider {
+    /**
+     * Logger for this provider, using SLF4J.
+     */
+    private final LoggingService logger = new SLF4JLoggingService(AccountTimeZoneProvider.class);
+
+    /**
+     * Returns the priority of this provider. Lower values indicate higher priority.
+     *
+     * @return the priority value (10)
+     */
+    @Override
+    public int getPriority() {
+        return 10;
+    }
+
+    /**
+     * Returns the default {@link ZoneId} for the current account session.
+     * <p>
+     * Attempts to retrieve the account time zone from the current session. If unavailable, returns null.
+     *
+     * @return the account's default ZoneId, or null if not available
+     */
+    @Override
+    public ZoneId getDefaultTimeZone() {
+        try {
+            return AccountSessionHolder.get().getAccountTimeZone();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/sources/jpa/pom.xml
+++ b/sources/jpa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>tools.dynamia.modules.saas.parent</artifactId>
         <groupId>tools.dynamia.modules</groupId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <name>DynamiaModules - SaaS JPA</name>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>tools.dynamia.modules</groupId>
             <artifactId>tools.dynamia.modules.saas.api</artifactId>
-            <version>3.4.1</version>
+            <version>3.4.2</version>
         </dependency>
         <dependency>
             <groupId>tools.dynamia</groupId>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -68,7 +68,7 @@
 
         <oshi.version>6.5.0</oshi.version>
         <jna.version>5.14.0</jna.version>
-        <springboot.version>3.5.3</springboot.version>
+        <springboot.version>3.5.5</springboot.version>
     </properties>
 
     <modules>

--- a/sources/pom.xml
+++ b/sources/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>tools.dynamia.modules</groupId>
     <artifactId>tools.dynamia.modules.saas.parent</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <packaging>pom</packaging>
     <name>DynamiaModules - SaaS</name>
     <description>DynamiaTools extension to create SaaS applications with accounts control and multi tenants in same
@@ -59,7 +59,7 @@
     </scm>
 
     <properties>
-        <dynamiatools.version>5.4.0</dynamiatools.version>
+        <dynamiatools.version>5.4.1</dynamiatools.version>
         <entityfiles.version>7.4.0</entityfiles.version>
         <java.version>21</java.version>
         <maven.compiler>3.14.0</maven.compiler>

--- a/sources/remote/pom.xml
+++ b/sources/remote/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>tools.dynamia.modules.saas.parent</artifactId>
         <groupId>tools.dynamia.modules</groupId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>tools.dynamia.modules</groupId>
             <artifactId>tools.dynamia.modules.saas.jpa</artifactId>
-            <version>3.4.1</version>
+            <version>3.4.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
         <dependency>

--- a/sources/ui/pom.xml
+++ b/sources/ui/pom.xml
@@ -22,10 +22,10 @@
     <parent>
         <groupId>tools.dynamia.modules</groupId>
         <artifactId>tools.dynamia.modules.saas.parent</artifactId>
-        <version>3.4.1</version>
+        <version>3.4.2</version>
     </parent>
     <artifactId>tools.dynamia.modules.saas.ui</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <name>DynamiaModules - SaaS UI</name>
     <url>https://www.dynamia.tools/modules/saas</url>
 


### PR DESCRIPTION
This pull request introduces support for account-level time zone resolution in the SaaS module, alongside improvements to locale handling and project dependency updates. The main change is the addition of a new provider for account time zones, which complements the existing locale provider and ensures that both locale and time zone can be resolved per account session. Additionally, all Maven module versions and key dependencies have been updated for consistency and to keep the project current.

### Account Session Enhancements

* Added a new `AccountTimeZoneProvider` class that supplies the default time zone based on the current account session, similar to how locale is resolved. This enables account-specific time zone handling for SaaS environments.
* Updated `AccountSessionHolder` to store and resolve `ZoneId` for the account, including logic to load the time zone from the account and fall back to the system default if not set. Also refactored locale loading for clarity and error handling. 

### Provider Documentation

* Improved Javadoc comments for `AccountLocaleProvider` to clarify its purpose, usage, and priority in locale resolution.

### Dependency and Version Updates

* Updated all module and dependency versions from `3.4.1` to `3.4.2` in `pom.xml` files across the codebase, ensuring consistency and compatibility. 
* Bumped key parent and property versions: `dynamiatools.version` to `5.4.1` and `springboot.version` to `3.5.5` in the root `pom.xml`. 